### PR TITLE
Refactoring

### DIFF
--- a/Relocator.cs
+++ b/Relocator.cs
@@ -6,8 +6,8 @@ using VRC.SDK3.Dynamics.PhysBone.Components;
 public class RelocatorWindow : EditorWindow
 {
 //properties
-    private static GameObject _source = null;
-    private bool _wasMissingDetected = false;
+    private static GameObject _source;
+    private bool _wasMissingDetected;
 
     private const string Version = "0.1.0";
     private static string _lang = "en-US";
@@ -51,21 +51,14 @@ public class RelocatorWindow : EditorWindow
     [MenuItem("Tools/PB Relocator", false, 1)]
     public static void ShowWindow()
     {
-        RelocatorWindow window = GetWindow<RelocatorWindow>("PB Relocator v" + Version);
+        GetWindow<RelocatorWindow>("PB Relocator v" + Version);
     }
 
     private void OnGUI()
     {
         if (GUILayout.Button(Texts[_lang]["langSwitch"]))
         {
-            if (_lang == "en-US")
-            {
-                _lang = "ja-JP";
-            }
-            else
-            {
-                _lang = "en-US";
-            }
+            _lang = _lang == "en-US" ? "ja-JP" : "en-US";
         }
 
         EditorGUILayout.LabelField(Texts[_lang]["summary"], EditorStyles.wordWrappedLabel);
@@ -81,7 +74,7 @@ public class RelocatorWindow : EditorWindow
             {
                 Undo.IncrementCurrentGroup();
                 Undo.SetCurrentGroupName("PB Relocation");
-                int undoIndex = Undo.GetCurrentGroup();
+                var undoIndex = Undo.GetCurrentGroup();
 
                 RelocatePhysBoneComponent();
                 RelocatePhysBoneColliderComponent();
@@ -108,21 +101,20 @@ public class RelocatorWindow : EditorWindow
 
     private void RelocatePhysBoneComponent()
     {
-        VRCPhysBone[] physBones = _source.GetComponents<VRCPhysBone>();
-        foreach (VRCPhysBone physBone in physBones)
+        foreach (var physBone in _source.GetComponents<VRCPhysBone>())
         {
-            Transform rootTransform = physBone.rootTransform;
+            var rootTransform = physBone.rootTransform;
             if (rootTransform == null)
             {
                 //Missing or None
-                SerializedProperty serializedProperty = new SerializedObject(physBone).FindProperty("rootTransform");
+                var serializedProperty = new SerializedObject(physBone).FindProperty("rootTransform");
                 if (serializedProperty.propertyType != SerializedPropertyType.ObjectReference ||
                     serializedProperty.objectReferenceValue != null)
                 {
                     continue;
                 }
 
-                SerializedProperty fileID = serializedProperty.FindPropertyRelative("m_FileID");
+                var fileID = serializedProperty.FindPropertyRelative("m_FileID");
                 if (fileID == null || fileID.intValue == 0)
                 {
                     continue;
@@ -142,15 +134,13 @@ public class RelocatorWindow : EditorWindow
 
     private void RelocatePhysBoneColliderComponent()
     {
-        VRCPhysBoneCollider[] physBoneColliders = _source.GetComponents<VRCPhysBoneCollider>();
-        foreach (VRCPhysBoneCollider physBoneCollider in physBoneColliders)
+        foreach (var physBoneCollider in _source.GetComponents<VRCPhysBoneCollider>())
         {
-            Transform rootTransform = physBoneCollider.rootTransform;
+            var rootTransform = physBoneCollider.rootTransform;
             if (rootTransform == null)
             {
                 //Missing or None
-                SerializedProperty serializedProperty =
-                    new SerializedObject(physBoneCollider).FindProperty("rootTransform");
+                var serializedProperty = new SerializedObject(physBoneCollider).FindProperty("rootTransform");
                 if (serializedProperty.propertyType != SerializedPropertyType.ObjectReference ||
                     serializedProperty.objectReferenceValue != null)
                 {

--- a/Relocator.cs
+++ b/Relocator.cs
@@ -6,13 +6,13 @@ using VRC.SDK3.Dynamics.PhysBone.Components;
 public class RelocatorWindow : EditorWindow
 {
 //properties
-    private static GameObject source = null;
-    private bool wasMissingDetected = false;
+    private static GameObject _source = null;
+    private bool _wasMissingDetected = false;
 
-    private static readonly string version = "0.1.0";
-    private static string lang = "en-US";
+    private const string Version = "0.1.0";
+    private static string _lang = "en-US";
 
-    private static readonly Dictionary<string, Dictionary<string, string>> texts =
+    private static readonly Dictionary<string, Dictionary<string, string>> Texts =
         new Dictionary<string, Dictionary<string, string>>()
         {
             {
@@ -51,29 +51,29 @@ public class RelocatorWindow : EditorWindow
     [MenuItem("Tools/PB Relocator", false, 1)]
     public static void ShowWindow()
     {
-        RelocatorWindow window = GetWindow<RelocatorWindow>("PB Relocator v" + version);
+        RelocatorWindow window = GetWindow<RelocatorWindow>("PB Relocator v" + Version);
     }
 
     private void OnGUI()
     {
-        if (GUILayout.Button(texts[lang]["langSwitch"]))
+        if (GUILayout.Button(Texts[_lang]["langSwitch"]))
         {
-            if (lang == "en-US")
+            if (_lang == "en-US")
             {
-                lang = "ja-JP";
+                _lang = "ja-JP";
             }
             else
             {
-                lang = "en-US";
+                _lang = "en-US";
             }
         }
 
-        EditorGUILayout.LabelField(texts[lang]["summary"], EditorStyles.wordWrappedLabel);
+        EditorGUILayout.LabelField(Texts[_lang]["summary"], EditorStyles.wordWrappedLabel);
 
-        source = (GameObject)EditorGUILayout.ObjectField(texts[lang]["source"], source, typeof(GameObject), true);
-        if (source == null)
+        _source = (GameObject)EditorGUILayout.ObjectField(Texts[_lang]["source"], _source, typeof(GameObject), true);
+        if (_source == null)
         {
-            EditorGUILayout.LabelField(texts[lang]["noSource"]);
+            EditorGUILayout.LabelField(Texts[_lang]["noSource"]);
         }
         else if (GUILayout.Button("Relocate!"))
         {
@@ -83,39 +83,39 @@ public class RelocatorWindow : EditorWindow
                 Undo.SetCurrentGroupName("PB Relocation");
                 int undoIndex = Undo.GetCurrentGroup();
 
-                relocatePhysBoneComponent();
-                relocatePhysBoneColliderComponent();
+                RelocatePhysBoneComponent();
+                RelocatePhysBoneColliderComponent();
 
                 Undo.CollapseUndoOperations(undoIndex);
 
-                if (wasMissingDetected)
+                if (_wasMissingDetected)
                 {
-                    EditorUtility.DisplayDialog("Result", texts[lang]["Succeeded-Missing"], "OK");
-                    wasMissingDetected = false;
+                    EditorUtility.DisplayDialog("Result", Texts[_lang]["Succeeded-Missing"], "OK");
+                    _wasMissingDetected = false;
                 }
                 else
                 {
-                    EditorUtility.DisplayDialog("Result", texts[lang]["Succeeded"], "OK");
+                    EditorUtility.DisplayDialog("Result", Texts[_lang]["Succeeded"], "OK");
                 }
             }
             catch (System.Exception e)
             {
-                EditorUtility.DisplayDialog("Error", e.Message + texts[lang]["msgWhenError"], "OK");
+                EditorUtility.DisplayDialog("Error", e.Message + Texts[_lang]["msgWhenError"], "OK");
                 Debug.LogError(e);
             }
         }
     }
 
-    private void relocatePhysBoneComponent()
+    private void RelocatePhysBoneComponent()
     {
-        VRCPhysBone[] physbones = source.GetComponents<VRCPhysBone>();
-        foreach (VRCPhysBone physbone in physbones)
+        VRCPhysBone[] physBones = _source.GetComponents<VRCPhysBone>();
+        foreach (VRCPhysBone physBone in physBones)
         {
-            Transform rootTransform = physbone.rootTransform;
+            Transform rootTransform = physBone.rootTransform;
             if (rootTransform == null)
             {
                 //Missing or None
-                SerializedProperty serializedProperty = new SerializedObject(physbone).FindProperty("rootTransform");
+                SerializedProperty serializedProperty = new SerializedObject(physBone).FindProperty("rootTransform");
                 if (serializedProperty.propertyType != SerializedPropertyType.ObjectReference ||
                     serializedProperty.objectReferenceValue != null)
                 {
@@ -128,29 +128,29 @@ public class RelocatorWindow : EditorWindow
                     continue;
                 }
 
-                wasMissingDetected = true;
+                _wasMissingDetected = true;
                 Debug.LogWarning("Missing detected!");
             }
             else
             {
-                UnityEditorInternal.ComponentUtility.CopyComponent(physbone);
+                UnityEditorInternal.ComponentUtility.CopyComponent(physBone);
                 UnityEditorInternal.ComponentUtility.PasteComponentAsNew(rootTransform.gameObject);
-                Undo.DestroyObjectImmediate(physbone);
+                Undo.DestroyObjectImmediate(physBone);
             }
         }
     }
 
-    private void relocatePhysBoneColliderComponent()
+    private void RelocatePhysBoneColliderComponent()
     {
-        VRCPhysBoneCollider[] physboneColliders = source.GetComponents<VRCPhysBoneCollider>();
-        foreach (VRCPhysBoneCollider physboneCollider in physboneColliders)
+        VRCPhysBoneCollider[] physBoneColliders = _source.GetComponents<VRCPhysBoneCollider>();
+        foreach (VRCPhysBoneCollider physBoneCollider in physBoneColliders)
         {
-            Transform rootTransform = physboneCollider.rootTransform;
+            Transform rootTransform = physBoneCollider.rootTransform;
             if (rootTransform == null)
             {
                 //Missing or None
                 SerializedProperty serializedProperty =
-                    new SerializedObject(physboneCollider).FindProperty("rootTransform");
+                    new SerializedObject(physBoneCollider).FindProperty("rootTransform");
                 if (serializedProperty.propertyType != SerializedPropertyType.ObjectReference ||
                     serializedProperty.objectReferenceValue != null)
                 {
@@ -163,14 +163,14 @@ public class RelocatorWindow : EditorWindow
                     continue;
                 }
 
-                wasMissingDetected = true;
+                _wasMissingDetected = true;
                 Debug.LogWarning("Missing detected!");
             }
             else
             {
-                UnityEditorInternal.ComponentUtility.CopyComponent(physboneCollider);
+                UnityEditorInternal.ComponentUtility.CopyComponent(physBoneCollider);
                 UnityEditorInternal.ComponentUtility.PasteComponentAsNew(rootTransform.gameObject);
-                Undo.DestroyObjectImmediate(physboneCollider);
+                Undo.DestroyObjectImmediate(physBoneCollider);
             }
         }
     }

--- a/Relocator.cs
+++ b/Relocator.cs
@@ -3,57 +3,82 @@ using UnityEditor;
 using UnityEngine;
 using VRC.SDK3.Dynamics.PhysBone.Components;
 
-public class RelocatorWindow : EditorWindow{
+public class RelocatorWindow : EditorWindow
+{
 //properties
     private static GameObject source = null;
     private bool wasMissingDetected = false;
 
     private static readonly string version = "0.1.0";
     private static string lang = "en-US";
-    private static readonly Dictionary<string, Dictionary<string, string>> texts = new Dictionary<string, Dictionary<string, string>>(){
-        {"en-US", new Dictionary<string, string>(){
-            {"langSwitch", "Switch language to Japanese/日本語にする"},
-            {"summary", "Relocate the PhysBone and PhysBoneCollider Components to the object set in the \"Root Transform\".\nSet a GameObject which has the target PhysBone or PhysBoneCollider Components, and press \"Relocate!\"."},
-            {"msgWhenError", "\n\nIf this error is unexpected, please contact the author of this extension."},
-            {"source", "Target GameObject"},
-            {"noSource", "You need to set a GameObject."},
-            {"Succeeded-Missing", "Succeeded, but missing was detected.\nIt is recommended to check."},
-            {"Succeeded", "Succeeded!"}
+
+    private static readonly Dictionary<string, Dictionary<string, string>> texts =
+        new Dictionary<string, Dictionary<string, string>>()
+        {
+            {
+                "en-US", new Dictionary<string, string>()
+                {
+                    { "langSwitch", "Switch language to Japanese/日本語にする" },
+                    {
+                        "summary",
+                        "Relocate the PhysBone and PhysBoneCollider Components to the object set in the \"Root Transform\".\nSet a GameObject which has the target PhysBone or PhysBoneCollider Components, and press \"Relocate!\"."
+                    },
+                    { "msgWhenError", "\n\nIf this error is unexpected, please contact the author of this extension." },
+                    { "source", "Target GameObject" },
+                    { "noSource", "You need to set a GameObject." },
+                    { "Succeeded-Missing", "Succeeded, but missing was detected.\nIt is recommended to check." },
+                    { "Succeeded", "Succeeded!" }
+                }
+            },
+            {
+                "ja-JP", new Dictionary<string, string>()
+                {
+                    { "langSwitch", "Switch language to English/英語にする" },
+                    {
+                        "summary",
+                        "PhysBoneコンポーネント類を\"Root Transform\"に設定されているゲームオブジェクトに再配置します。\n対象のPhysBoneコンポーネント類を含むゲームオブジェクトをセットし、\"Relocate!\"ボタンを押してください。"
+                    },
+                    { "msgWhenError", "\n\nこのエラーに心当たりが無い場合は、この拡張の作者に連絡してみてください。" },
+                    { "source", "対象のゲームオブジェクト" },
+                    { "noSource", "ゲームオブジェクトをセットする必要があります。" },
+                    { "Succeeded-Missing", "成功しましたが、Root Transformがmissingになっているオブジェクトが見つかりました。\n確認することをお勧めします。" },
+                    { "Succeeded", "成功！" }
+                }
             }
-        },
-        {"ja-JP", new Dictionary<string, string>(){
-            {"langSwitch", "Switch language to English/英語にする"},
-            {"summary", "PhysBoneコンポーネント類を\"Root Transform\"に設定されているゲームオブジェクトに再配置します。\n対象のPhysBoneコンポーネント類を含むゲームオブジェクトをセットし、\"Relocate!\"ボタンを押してください。"},
-            {"msgWhenError", "\n\nこのエラーに心当たりが無い場合は、この拡張の作者に連絡してみてください。"},
-            {"source", "対象のゲームオブジェクト"},
-            {"noSource", "ゲームオブジェクトをセットする必要があります。"},
-            {"Succeeded-Missing", "成功しましたが、Root Transformがmissingになっているオブジェクトが見つかりました。\n確認することをお勧めします。"},
-            {"Succeeded", "成功！"}
-            }
-        }
-    };
+        };
 
 //methods
     [MenuItem("Tools/PB Relocator", false, 1)]
-    public static void ShowWindow(){
+    public static void ShowWindow()
+    {
         RelocatorWindow window = GetWindow<RelocatorWindow>("PB Relocator v" + version);
     }
 
-    private void OnGUI(){
-        if(GUILayout.Button(texts[lang]["langSwitch"])){
-            if(lang == "en-US"){
+    private void OnGUI()
+    {
+        if (GUILayout.Button(texts[lang]["langSwitch"]))
+        {
+            if (lang == "en-US")
+            {
                 lang = "ja-JP";
-            }else{
+            }
+            else
+            {
                 lang = "en-US";
             }
         }
+
         EditorGUILayout.LabelField(texts[lang]["summary"], EditorStyles.wordWrappedLabel);
 
         source = (GameObject)EditorGUILayout.ObjectField(texts[lang]["source"], source, typeof(GameObject), true);
-        if(source == null){
+        if (source == null)
+        {
             EditorGUILayout.LabelField(texts[lang]["noSource"]);
-        }else if(GUILayout.Button("Relocate!")){
-            try{
+        }
+        else if (GUILayout.Button("Relocate!"))
+        {
+            try
+            {
                 Undo.IncrementCurrentGroup();
                 Undo.SetCurrentGroupName("PB Relocation");
                 int undoIndex = Undo.GetCurrentGroup();
@@ -63,35 +88,51 @@ public class RelocatorWindow : EditorWindow{
 
                 Undo.CollapseUndoOperations(undoIndex);
 
-                if(wasMissingDetected){
+                if (wasMissingDetected)
+                {
                     EditorUtility.DisplayDialog("Result", texts[lang]["Succeeded-Missing"], "OK");
                     wasMissingDetected = false;
-                }else{
+                }
+                else
+                {
                     EditorUtility.DisplayDialog("Result", texts[lang]["Succeeded"], "OK");
                 }
-            }catch(System.Exception e){
+            }
+            catch (System.Exception e)
+            {
                 EditorUtility.DisplayDialog("Error", e.Message + texts[lang]["msgWhenError"], "OK");
                 Debug.LogError(e);
             }
         }
     }
 
-    private void relocatePhysBoneComponent(){
+    private void relocatePhysBoneComponent()
+    {
         VRCPhysBone[] physbones = source.GetComponents<VRCPhysBone>();
-        foreach(VRCPhysBone physbone in physbones){
+        foreach (VRCPhysBone physbone in physbones)
+        {
             Transform rootTransform = physbone.rootTransform;
-            if(rootTransform == null){//Missing or None
+            if (rootTransform == null)
+            {
+                //Missing or None
                 SerializedProperty serializedProperty = new SerializedObject(physbone).FindProperty("rootTransform");
-                if(serializedProperty.propertyType != SerializedPropertyType.ObjectReference || serializedProperty.objectReferenceValue != null){
+                if (serializedProperty.propertyType != SerializedPropertyType.ObjectReference ||
+                    serializedProperty.objectReferenceValue != null)
+                {
                     continue;
                 }
+
                 SerializedProperty fileID = serializedProperty.FindPropertyRelative("m_FileID");
-                if(fileID == null || fileID.intValue == 0){
+                if (fileID == null || fileID.intValue == 0)
+                {
                     continue;
                 }
+
                 wasMissingDetected = true;
                 Debug.LogWarning("Missing detected!");
-            }else{
+            }
+            else
+            {
                 UnityEditorInternal.ComponentUtility.CopyComponent(physbone);
                 UnityEditorInternal.ComponentUtility.PasteComponentAsNew(rootTransform.gameObject);
                 Undo.DestroyObjectImmediate(physbone);
@@ -99,22 +140,34 @@ public class RelocatorWindow : EditorWindow{
         }
     }
 
-    private void relocatePhysBoneColliderComponent(){
+    private void relocatePhysBoneColliderComponent()
+    {
         VRCPhysBoneCollider[] physboneColliders = source.GetComponents<VRCPhysBoneCollider>();
-        foreach(VRCPhysBoneCollider physboneCollider in physboneColliders){
+        foreach (VRCPhysBoneCollider physboneCollider in physboneColliders)
+        {
             Transform rootTransform = physboneCollider.rootTransform;
-            if(rootTransform == null){//Missing or None
-                SerializedProperty serializedProperty = new SerializedObject(physboneCollider).FindProperty("rootTransform");
-                if(serializedProperty.propertyType != SerializedPropertyType.ObjectReference || serializedProperty.objectReferenceValue != null){
+            if (rootTransform == null)
+            {
+                //Missing or None
+                SerializedProperty serializedProperty =
+                    new SerializedObject(physboneCollider).FindProperty("rootTransform");
+                if (serializedProperty.propertyType != SerializedPropertyType.ObjectReference ||
+                    serializedProperty.objectReferenceValue != null)
+                {
                     continue;
                 }
+
                 SerializedProperty fileID = serializedProperty.FindPropertyRelative("m_FileID");
-                if(fileID == null || fileID.intValue == 0){
+                if (fileID == null || fileID.intValue == 0)
+                {
                     continue;
                 }
+
                 wasMissingDetected = true;
                 Debug.LogWarning("Missing detected!");
-            }else{
+            }
+            else
+            {
                 UnityEditorInternal.ComponentUtility.CopyComponent(physboneCollider);
                 UnityEditorInternal.ComponentUtility.PasteComponentAsNew(rootTransform.gameObject);
                 Undo.DestroyObjectImmediate(physboneCollider);


### PR DESCRIPTION
Reformat with .NET-popular rule.
Rename to .NET-popular rule.
Apply Rider's inspections like 'use var' instead of explicit type.